### PR TITLE
Making `.system()` call optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ fn main() {
 
     // Create a Dispatcher to run our systems.
     let mut dispatcher = Dispatcher::builder()
-        .add_system(update_velocity.system())
-        .add_system(update_position.system())
+        .add_system(update_velocity)
+        .add_system(update_position)
         .build();
 
     // Register all component types we want to use.

--- a/examples/components.rs
+++ b/examples/components.rs
@@ -34,10 +34,8 @@ fn update_position(mut pos: CompMut<Position>, vel: Comp<Velocity>) {
 }
 
 fn main() {
-    let mut dispatcher = Dispatcher::builder()
-        .add_system(update_velocity.system())
-        .add_system(update_position.system())
-        .build();
+    let mut dispatcher =
+        Dispatcher::builder().add_system(update_velocity).add_system(update_position).build();
 
     let mut world = World::default();
     dispatcher.register_storages(&mut world);

--- a/examples/errors.rs
+++ b/examples/errors.rs
@@ -16,11 +16,7 @@ fn c() -> SystemResult {
 }
 
 fn main() {
-    let mut dispatcher = Dispatcher::builder()
-        .add_system(a.system())
-        .add_system(b.system())
-        .add_system(c.system())
-        .build();
+    let mut dispatcher = Dispatcher::builder().add_system(a).add_system(b).add_system(c).build();
 
     let mut world = World::default();
 

--- a/examples/filters.rs
+++ b/examples/filters.rs
@@ -43,10 +43,8 @@ fn print_health(hps: Comp<Hp>) {
 }
 
 fn main() {
-    let mut dispatcher = Dispatcher::builder()
-        .add_system(apply_difficulty.system())
-        .add_system(print_health.system())
-        .build();
+    let mut dispatcher =
+        Dispatcher::builder().add_system(apply_difficulty).add_system(print_health).build();
 
     let mut world = World::default();
     dispatcher.register_storages(&mut world);

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -40,7 +40,7 @@ fn print_sprites(pos: Comp<Position>, sprites: Comp<Sprite>, transparencies: Com
 }
 
 fn main() {
-    let mut dispatcher = Dispatcher::builder().add_system(print_sprites.system()).build();
+    let mut dispatcher = Dispatcher::builder().add_system(print_sprites).build();
 
     let layout = Layout::builder()
         .add_group(<(Position, Sprite)>::group())

--- a/examples/parallelism.rs
+++ b/examples/parallelism.rs
@@ -29,10 +29,8 @@ fn update_movement(mut pos: CompMut<Position>, vels: Comp<Velocity>) {
 }
 
 fn main() {
-    let mut dispatcher = Dispatcher::builder()
-        .add_system(update_health.system())
-        .add_system(update_movement.system())
-        .build();
+    let mut dispatcher =
+        Dispatcher::builder().add_system(update_health).add_system(update_movement).build();
 
     let mut world = World::default();
     dispatcher.register_storages(&mut world);

--- a/src/systems/dispatcher.rs
+++ b/src/systems/dispatcher.rs
@@ -1,7 +1,7 @@
 use crate::storage::Ticks;
 use crate::systems::{
-    CommandBuffers, LocalFn, LocalSystem, Registry, RegistryAccess, RunError, RunResult, Runnable,
-    System, SystemError,
+    CommandBuffers, IntoLocalSystem, IntoSystem, LocalFn, LocalSystem, Registry, RegistryAccess,
+    RunError, RunResult, Runnable, System, SystemError,
 };
 use crate::world::{World, WorldId};
 use rustc_hash::FxHashMap;
@@ -21,14 +21,14 @@ pub struct DispatcherBuilder {
 
 impl DispatcherBuilder {
     /// Add a system to the `Dispatcher`.
-    pub fn add_system(&mut self, system: System) -> &mut Self {
-        self.simple_steps.push(SimpleStep::RunSystem(system));
+    pub fn add_system<P, R>(&mut self, system: impl IntoSystem<P, R>) -> &mut Self {
+        self.simple_steps.push(SimpleStep::RunSystem(system.system()));
         self
     }
 
     /// Add a local system to the `Dispatcher` which runs on the current thread.
-    pub fn add_local_system(&mut self, system: LocalSystem) -> &mut Self {
-        self.simple_steps.push(SimpleStep::RunLocalSystem(system));
+    pub fn add_local_system<P, R>(&mut self, system: impl IntoLocalSystem<P, R>) -> &mut Self {
+        self.simple_steps.push(SimpleStep::RunLocalSystem(system.local_system()));
         self
     }
 

--- a/src/systems/system.rs
+++ b/src/systems/system.rs
@@ -65,10 +65,22 @@ unsafe impl IntoLocalSystem<(), ()> for System {
     }
 }
 
+unsafe impl<P, R> IntoLocalSystem<P, R> for LocalSystem {
+    fn local_system(self) -> LocalSystem {
+        self
+    }
+}
+
 /// Helper trait for creating a `System` from a system function.
 pub unsafe trait IntoSystem<Params, Return>: IntoLocalSystem<Params, Return> {
     /// Creates a `System` with the system function.
     fn system(self) -> System;
+}
+
+unsafe impl IntoSystem<(), ()> for System {
+    fn system(self) -> System {
+        self
+    }
 }
 
 /// Encapsulates a system function with exclusive access to `World`.

--- a/src/systems/system_param.rs
+++ b/src/systems/system_param.rs
@@ -1,17 +1,17 @@
 use crate::components::Component;
 use crate::resources::Resource;
-use crate::systems::{BorrowRegistry, Commands};
+use crate::systems::{Commands, IntoBorrowRegistry};
 use crate::world::{Comp, CompMut, Res, ResMut};
 
 /// Trait used for marking system parameters and borrowing data from the
 /// `Registry`.
-pub trait LocalSystemParam: for<'a> BorrowRegistry<'a> {
+pub trait LocalSystemParam: IntoBorrowRegistry {
     // Empty
 }
 
 impl<T> LocalSystemParam for T
 where
-    T: for<'a> BorrowRegistry<'a>,
+    T: IntoBorrowRegistry,
 {
     // Empty
 }


### PR DESCRIPTION
This PR removes `.system()` calls hiring some hack from `shipyard` and `bevy`.

@leudz gave me super great explanation on Discord and I'd like to share the trick with you, but my PR would not be perfect, so feel free to edit/reject this PR :)

---

Tricks:

* [GAT hack explanation][S] by @leudz (This is gem! Thank you sooo much.)
* `inner` function hack from Bevy for `for<'a> &'a mut FnMut`: [function_system.rs#508](https://github.com/bevyengine/bevy/blob/6bc5c609867908345f0b427cbd2725082883b31c/crates/bevy_ecs/src/system/function_system.rs#L508)

[S]: https://leudz.github.io/shipyard/guide/master/going-deeper/workload-creation.html

(Edit: now that the hack is published on the shipyard's guide, I removed the long quotes)